### PR TITLE
Improve extension output

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ uvicorn server:app --reload --host 0.0.0.0 --port 8000
 1. Przejdź na dowolną stronę z tekstem.
 2. Kliknij ikonę rozszerzenia ScamScanner 🕵️‍♂️.
 3. W popupie naciśnij **Scan** 🖱️.
-4. Wynik pojawi się w alertcie lub konsoli deweloperskiej 🎉.
+4. Na stronie pojawi się panel z informacją o postępie ⏳.
+5. Po zakończeniu zobaczysz wynik oraz czas wykonania analizy 🎉.
 
 ---
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,7 +1,33 @@
+// Tworzy (lub aktualizuje) panel z wynikiem na stronie
+function ensurePanel() {
+  if (!document.getElementById('scamscanner-style')) {
+    const link = document.createElement('link');
+    link.id = 'scamscanner-style';
+    link.rel = 'stylesheet';
+    link.href = chrome.runtime.getURL('inject.css');
+    document.head.appendChild(link);
+  }
+
+  let panel = document.getElementById('scamscanner-panel');
+  if (!panel) {
+    panel = document.createElement('div');
+    panel.id = 'scamscanner-panel';
+    panel.innerHTML = '<h3>ScamScanner</h3><div class="status"></div><div class="result"></div>';
+    document.body.prepend(panel);
+  }
+  return panel;
+}
+
 // Pobranie tekstu (np. zaznaczonego przez użytkownika) i wysłanie do API
 async function analyzeSelectedText() {
-  // Przykładowy sposób pobrania tekstu z aktywnej strony:
   const selectedText = window.getSelection().toString() || document.body.innerText;
+
+  const panel = ensurePanel();
+  const statusEl = panel.querySelector('.status');
+  const resultEl = panel.querySelector('.result');
+  resultEl.textContent = '';
+  statusEl.innerHTML = '<span class="spinner"></span> Analiza w toku...';
+  const start = performance.now();
 
   try {
     const response = await fetch('http://127.0.0.1:8000/analyze', {
@@ -12,10 +38,12 @@ async function analyzeSelectedText() {
 
     if (!response.ok) throw new Error(`Błąd serwera: ${response.status}`);
     const data = await response.json();
-    console.log('Wynik analizy:', data);
-    alert(`Wynik: ${data.result}`);
+    const time = ((performance.now() - start) / 1000).toFixed(1);
+    statusEl.textContent = `Gotowe w ${time}s`;
+    resultEl.textContent = data.result;
   } catch (err) {
     console.error(err);
+    statusEl.textContent = 'Błąd połączenia';
     alert(`Nie udało się połączyć: ${err.message}`);
   }
 }

--- a/extension/inject.css
+++ b/extension/inject.css
@@ -1,12 +1,38 @@
 #scamscanner-panel {
   border: 2px solid #007BFF;
   background: #F0F8FF;
-  padding: 12px; margin: 10px auto;
-  max-width: 800px; font-family: Arial, sans-serif;
+  padding: 12px;
+  margin: 10px auto;
+  max-width: 800px;
+  font-family: Arial, sans-serif;
   z-index: 9999;
 }
-#scamscanner-panel h3 { margin: 0 0 8px; color: #0056b3; }
+#scamscanner-panel h3 {
+  margin: 0 0 8px;
+  color: #0056b3;
+}
+#scamscanner-panel .status {
+  font-size: 0.85rem;
+  color: #555;
+  margin-bottom: 8px;
+}
 #scamscanner-panel .result {
-  white-space: pre-wrap; max-height: 300px; overflow-y: auto;
+  white-space: pre-wrap;
+  max-height: 300px;
+  overflow-y: auto;
   font-size: 0.9rem;
+}
+.spinner {
+  border: 2px solid #ccc;
+  border-top-color: #007BFF;
+  border-radius: 50%;
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  animation: spin 0.6s linear infinite;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,5 +20,11 @@
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
     }
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["inject.css"],
+      "matches": ["<all_urls>"]
+    }
+  ]
 }

--- a/extension/options.css
+++ b/extension/options.css
@@ -1,0 +1,5 @@
+body { font-family: Arial, sans-serif; padding: 10px; }
+h2 { color: #0056b3; }
+label { display: block; margin-bottom: 8px; }
+button { padding: 6px 12px; background:#007BFF; color:#fff; border:none; border-radius:4px; cursor:pointer; }
+#status { margin-top:8px; color:green; }


### PR DESCRIPTION
## Summary
- show analysis result in-page instead of using alert
- expose inject.css via web_accessible_resources
- update README usage instructions
- show progress and execution time in injected panel
- style options page

## Testing
- `python3 -m py_compile backend/server.py backend/main.py`
- `node -e "console.log('test')"`

------
https://chatgpt.com/codex/tasks/task_e_6856a1b596988331a9433f1e7f91e181