### PR TITLE
Add one-step launcher and clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ ScamScanner-Extension to **rozszerzenie przegladarki** wspierane przez niewielki
 
 ## ⚙️ Funkcjonalnosci
 
- wl279k-codex/wyświetl-wynik-analizy-w-oknie-przeglądarki
 * 🔍 Analiza zaznaczonego tekstu lub calej strony
 * 🤖 Generowanie odpowiedzi lokalnym modelem (lista modeli w popupie)
 * 🛠️ Wybór modeli (GPT-2, DistilGPT-2, LLaMA 2, Mistral 7B, GPT4All Vicuna)
@@ -45,7 +44,6 @@ ScamScanner-Extension to **rozszerzenie przegladarki** wspierane przez niewielki
 * 🧠 Wyszukiwanie w bazie embeddingów (FAISS)
 * 🗄️ API do dodawania dokumentów i zapytań
 * ✅ Opcjonalny fact-checking przed zwróceniem odpowiedzi
-main
 
 ---
 
@@ -61,7 +59,7 @@ Uniwersalna instrukcja instalacji i uruchomienia projektu **ScamScanner** (backe
 
 * Python 3.8+
 * Git (opcjonalnie, jeśli chcesz klonować repo)
-* Przeglądarka Chrome lub Firefox
+* Przeglądarka Chrome, Edge lub Firefox
 * (Windows) Uprawnienia do zmiany Execution Policy w PowerShell
 
 ---
@@ -135,6 +133,14 @@ uvicorn server:app --host 0.0.0.0 --port 8000
 
 Powinieneś zobaczyć komunikat, że FastAPI nasłuchuje na porcie 8000.
 
+### 2.5 Szybki start
+
+W głównym katalogu projektu możesz uruchomić backend i otworzyć przeglądarkę z wczytanym rozszerzeniem jednym poleceniem:
+
+```bash
+python start.py
+```
+
 ---
 
 ## 3. Rozszerzenie do przeglądarki
@@ -142,13 +148,12 @@ Powinieneś zobaczyć komunikat, że FastAPI nasłuchuje na porcie 8000.
 1. Otwórz stronę zarządzania rozszerzeniami w przeglądarce:
 
    * **Chrome**: `chrome://extensions/`
+   * **Edge**: `edge://extensions/`
    * **Firefox**: `about:debugging#/runtime/this-firefox`
 2. Włącz tryb dewelopera / Developer mode.
-3. Kliknij **Load unpacked** (Chrome) lub **Load Temporary Add-on** (Firefox) i wskaż folder:
-
-   ```
-   /ścieżka/do/ScamScanner-Extension-main/extension
-   ```
+3. **Chrome/Edge** – kliknij **Load unpacked** i wskaż katalog `extension` (tam, gdzie znajduje się `manifest.json`).
+   **Firefox** – kliknij **Load Temporary Add-on** i wybierz plik `manifest.json` z katalogu `extension`.
+   Jeśli przeglądarka nie pozwala wybrać pliku lub katalogu, upewnij się, że cały projekt został wcześniej rozpakowany z archiwum ZIP.
 4. Po załadowaniu zobaczysz ikonę rozszerzenia na pasku narzędzi.
 
 ---

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,8 +1,8 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
-    openai_api_key: str
-    newsapi_key: str
+    openai_api_key: str = ""
+    newsapi_key: str = ""
     local_model: str = "gpt2-medium"
     max_length: int = 512
     temperature: float = 0.7

--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -1,35 +1,3 @@
-wl279k-codex/wyświetl-wynik-analizy-w-oknie-przeglądarki
-from collections import Counter
-from typing import List
-
-
-def _embed(text: str) -> Counter:
-    return Counter(text.lower().split())
-
-
-class EmbeddingStore:
-    """Simple in-memory store using bag-of-words Jaccard similarity."""
-
-    def __init__(self):
-        self.texts: List[str] = []
-        self.vectors: List[Counter] = []
-
-    def add(self, text: str) -> None:
-        self.texts.append(text)
-        self.vectors.append(_embed(text))
-
-    def search(self, query: str, k: int = 3) -> List[str]:
-        if not self.texts:
-            return []
-        q = _embed(query)
-
-        def score(v: Counter) -> float:
-            inter = sum((q & v).values())
-            union = sum((q | v).values())
-            return inter / union if union else 0.0
-
-        ranked = sorted(range(len(self.vectors)), key=lambda i: score(self.vectors[i]), reverse=True)
-        return [self.texts[i] for i in ranked[:k]]
 
 from sentence_transformers import SentenceTransformer
 import numpy as np

--- a/extension/content.js
+++ b/extension/content.js
@@ -20,7 +20,6 @@ function ensurePanel() {
 
 // Pobranie tekstu (np. zaznaczonego przez użytkownika) i wysłanie do API
 async function analyzeSelectedText(model = 'gpt2') {
-async function analyzeSelectedText() {
   const selectedText = window.getSelection().toString() || document.body.innerText;
 
   const panel = ensurePanel();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "ScamScanner",
   "version": "1.0.0",
-  "permissions": ["storage"],
+  "permissions": ["storage", "scripting"],
   "host_permissions": ["http://127.0.0.1:8000/*"],
   "background": {
     "service_worker": "background.js"

--- a/start.py
+++ b/start.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import shutil
+import subprocess
+import webbrowser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+EXT_DIR = ROOT / "extension"
+
+BACKEND_CMD = [sys.executable, "-m", "uvicorn", "backend.server:app", "--host", "127.0.0.1", "--port", "8000"]
+
+
+def find_browser():
+    for name in ["google-chrome", "chrome", "chromium", "msedge"]:
+        path = shutil.which(name)
+        if path:
+            return [path, f"--load-extension={EXT_DIR}"]
+    if shutil.which("firefox"):
+        return ["firefox"]
+    return None
+
+
+def main():
+    print("Starting backend server...")
+    backend = subprocess.Popen(BACKEND_CMD)
+    browser_cmd = find_browser()
+    if browser_cmd:
+        if "firefox" in browser_cmd[0]:
+            print("Firefox detected. Open about:debugging and load the extension manually from:", EXT_DIR)
+            webbrowser.open("about:debugging#/runtime/this-firefox")
+        else:
+            print("Launching browser with extension...")
+            subprocess.Popen(browser_cmd)
+    else:
+        print("No supported browser found. Please open Chrome/Edge with developer mode and load the extension from:", EXT_DIR)
+
+    try:
+        backend.wait()
+    except KeyboardInterrupt:
+        backend.terminate()
+        backend.wait()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- provide an easy launch script to start backend and open the extension
- remove leftover code from embedding store
- default env keys so tests run without `.env`
- document quick start in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856dcb8223c8331a97cb91e0c4c5e3f